### PR TITLE
feat(nvidia): NVIDIA GPU モジュールを新規追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
       adguard           = import ./modules/adguard.nix;
       networkProtection = import ./modules/network-protection.nix;
       desktop           = import ./modules/desktop.nix;
+      nvidia            = import ./modules/nvidia.nix;
       virtualization    = import ./modules/virtualization.nix;
       gnome             = import ./modules/gnome;
       hyprland          = import ./modules/hyprland;

--- a/modules/all.nix
+++ b/modules/all.nix
@@ -18,6 +18,7 @@
     ./firewall.nix
     ./network-protection.nix  # warp.nix と adguard.nix を内包
     ./desktop.nix
+    ./nvidia.nix
     ./virtualization.nix
     ./gnome
     ./hyprland
@@ -43,6 +44,9 @@
       # warp と adguard は networkProtection に内包されるため個別設定不要
       networkProtection.enable = lib.mkDefault true;
       desktop.enable           = lib.mkDefault true;
+      # nvidia はハードウェア依存のため false がデフォルト
+      # NVIDIA GPU を搭載したマシンは configuration.nix で明示的に有効化する
+      nvidia.enable            = lib.mkDefault false;
       virtualization.enable    = lib.mkDefault true;
       gnome.enable             = lib.mkDefault true;
       hyprland.enable          = lib.mkDefault true;

--- a/modules/boot.nix
+++ b/modules/boot.nix
@@ -13,7 +13,7 @@
   };
 
   config = lib.mkIf config.sashix.boot.enable {
-    boot.kernelPackages = pkgs.linuxPackages_latest;
+    boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
 
     # Enable systemd in initrd to allow systemd-cryptenroll for LUKS key enrollment
     boot.initrd.systemd.enable = true;

--- a/modules/nvidia.nix
+++ b/modules/nvidia.nix
@@ -1,0 +1,63 @@
+# NVIDIA GPU 設定 (Wayland / Hyprland 向け)
+#
+# 対象: Turing (RTX 20シリーズ) 以降の GPU
+#       Ada Lovelace (RTX 40シリーズ) では open = true が必須
+#
+# カーネル互換性:
+#   - NVIDIA open カーネルモジュール (open = true) は nixpkgs-unstable の
+#     production ドライバが linuxPackages_latest に対してビルドされるため、
+#     boot.nix が設定する linuxPackages_latest と組み合わせれば互換性は nixpkgs
+#     側で保証される。
+#   - そのため、以前必要だった `boot.kernelPackages = pkgs.linuxPackages_6_18;`
+#     のような明示的なピン留めは通常不要。
+#     カーネルアップデート直後に一時的にドライバビルドが壊れた場合のみ、
+#     設定ファイル側で boot.kernelPackages を上書きして対処する。
+#
+# 使い方:
+#   sashix.nvidia.enable = true;
+{ lib, config, ... }:
+
+{
+  options.sashix.nvidia = {
+    enable = lib.mkEnableOption "NVIDIA GPU configuration (Wayland / Hyprland)";
+  };
+
+  config = lib.mkIf config.sashix.nvidia.enable {
+
+    # --- ドライバ本体 -------------------------------------------------------
+    hardware.nvidia = {
+      # Wayland コンポジタ (Hyprland 等) に必須
+      modesetting.enable = true;
+
+      # GPU サスペンド/レジューム の安定性向上
+      powerManagement.enable = true;
+
+      # オープンソースカーネルモジュール
+      # Turing (RTX 20) 以降で使用可。Ada Lovelace (RTX 40) では推奨。
+      # Maxwell / Pascal / Volta は false にすること。
+      open = true;
+
+      # production ドライバ: config.boot.kernelPackages から自動解決されるため
+      # kernelPackages を変更するだけでドライバも追随する
+      package = config.boot.kernelPackages.nvidiaPackages.production;
+    };
+
+    # --- ハードウェアアクセラレーション -------------------------------------
+    # VA-API / OpenGL / Vulkan (32-bit 互換レイヤー含む)
+    hardware.graphics = {
+      enable = true;
+      enable32Bit = true;
+    };
+
+    # --- Wayland / NVIDIA 向け環境変数 (Hyprland 最適化) -------------------
+    environment.sessionVariables = {
+      NIXOS_OZONE_WL            = "1";
+      GBM_BACKEND               = "nvidia-drm";
+      __GLX_VENDOR_LIBRARY_NAME = "nvidia";
+      WLR_NO_HARDWARE_CURSORS   = "1";
+      LIBVA_DRIVER_NAME         = "nvidia";
+      XDG_SESSION_TYPE          = "wayland";
+    };
+
+  };
+}


### PR DESCRIPTION
- modules/nvidia.nix を新設
  - hardware.nvidia (modesetting / powerManagement / open / production)
  - hardware.graphics (VA-API・OpenGL・Vulkan、32bit 含む)
  - Wayland/Hyprland 向け environment.sessionVariables
- boot.nix: kernelPackages を lib.mkDefault に変更し上書き可能にする
- all.nix / flake.nix: nvidia モジュールを登録 (nvidia.enable のデフォルトは false — ハードウェア依存のため)

https://claude.ai/code/session_014ywdv7MQnKNH4TEtBT11J5