### PR TITLE
Fix NVIDIA driver conflicts with nouveau and prevent Wayland freeze

### DIFF
--- a/modules/nvidia.nix
+++ b/modules/nvidia.nix
@@ -49,6 +49,15 @@
       enable32Bit = true;
     };
 
+    # --- nouveau 競合防止 -------------------------------------------------------
+    # nouveau / nvidiafb / nova_core が NVIDIA プロプライエタリドライバと共存すると
+    # Wayland セッション開始時にシステムがフリーズする。
+    # nvidia-uvm は nvidia 本体がロードされた後に初期化する必要があるため softdep を設定。
+    boot.blacklistedKernelModules = [ "nouveau" "nvidiafb" "nova_core" ];
+    boot.extraModprobeConfig = ''
+      softdep nvidia post: nvidia-uvm
+    '';
+
     # --- Wayland / NVIDIA 向け環境変数 (Hyprland 最適化) -------------------
     environment.sessionVariables = {
       NIXOS_OZONE_WL            = "1";


### PR DESCRIPTION
## Summary
This change prevents kernel module conflicts between NVIDIA's proprietary driver and open-source alternatives (nouveau, nvidiafb, nova_core) that cause system freezes during Wayland session startup. It also ensures proper initialization order of the nvidia-uvm module.

## Key Changes
- Blacklist conflicting kernel modules (`nouveau`, `nvidiafb`, `nova_core`) to prevent them from loading alongside the NVIDIA proprietary driver
- Add softdep configuration to ensure `nvidia-uvm` is initialized after the main `nvidia` module loads

## Implementation Details
The fix uses two kernel configuration mechanisms:
1. **`boot.blacklistedKernelModules`**: Prevents the open-source drivers from being loaded, eliminating the conflict that causes Wayland to freeze
2. **`boot.extraModprobeConfig`**: Sets a soft dependency (`softdep nvidia post: nvidia-uvm`) to guarantee correct module initialization order, as nvidia-uvm requires the nvidia module to be loaded first

This is a targeted fix for systems using NVIDIA proprietary drivers with Hyprland/Wayland, addressing a known stability issue.

https://claude.ai/code/session_01AYm8w5ptX7yfUyhYWL5u3f