### PR TITLE
fix(nvidia): services.xserver.videoDrivers = ["nvidia"] を追加

### DIFF
--- a/modules/nvidia.nix
+++ b/modules/nvidia.nix
@@ -24,6 +24,9 @@
 
   config = lib.mkIf config.sashix.nvidia.enable {
 
+    # --- X / DRM ドライバ選択 -----------------------------------------------
+    services.xserver.videoDrivers = [ "nvidia" ];
+
     # --- ドライバ本体 -------------------------------------------------------
     hardware.nvidia = {
       # Wayland コンポジタ (Hyprland 等) に必須


### PR DESCRIPTION
hardware.nvidia モジュールの有効化トリガーとして必要な設定が
欠落していたため追加。

https://claude.ai/code/session_01AYm8w5ptX7yfUyhYWL5u3f