### PR TITLE
firewall: Enable loose reverse path filtering for tunnel interfaces

### DIFF
--- a/modules/firewall.nix
+++ b/modules/firewall.nix
@@ -2,6 +2,8 @@
 # - Default inbound policy: DROP (NixOS firewall drops uninvited inbound by default)
 # - Tailscale interface (tailscale0) trusted
 # - Tailscale UDP port allowed for direct peer connections
+# - checkReversePath = "loose": Tailscale exit-node / Cloudflare WARP tunnel_only モードで
+#   トンネル経由の折り返しパケット (送信元IP が外部IP) がドロップされるのを防ぐ
 { lib, config, ... }:
 
 {
@@ -21,6 +23,11 @@
 
       # Log refused connections (useful for debugging)
       logRefusedConnections = true;
+
+      # Tailscale exit-node / Cloudflare WARP (tunnel_only) 対応
+      # トンネルインターフェース (tailscale0 / CloudflareWARP) 経由で届く折り返しパケットは
+      # 送信元IPが外部IPになるため、strict だとスプーフィングと誤検知されドロップされる
+      checkReversePath = "loose";
     };
   };
 }


### PR DESCRIPTION
## Summary
Configure the NixOS firewall to use loose reverse path filtering (`checkReversePath = "loose"`) to support Tailscale exit-node and Cloudflare WARP tunnel modes.

## Changes
- Set `checkReversePath = "loose"` in the firewall configuration
- Added documentation explaining why this setting is necessary for tunnel-based traffic

## Details
When using Tailscale as an exit node or Cloudflare WARP in tunnel_only mode, return packets traverse the tunnel interface with external source IPs. With strict reverse path filtering (the default), the kernel would incorrectly identify these as spoofed packets and drop them. Switching to loose mode allows the firewall to accept these legitimate return packets while still maintaining security by only checking that a route exists for the source IP, rather than requiring it to arrive on the expected interface.

https://claude.ai/code/session_016SAqpN3mdF1aLVdDyL7aqt