### PR TITLE
feat(network-protection): warp.nix を除外し AdGuard のみに変更

### DIFF
--- a/modules/network-protection.nix
+++ b/modules/network-protection.nix
@@ -1,19 +1,18 @@
-# Network protection bundle: WARP + AdGuard
-# 個別に使う場合は warp.nix / adguard.nix を直接 import してください
+# Network protection bundle: AdGuard のみ
+# warp.nix を使う場合は直接 import してください
+# 個別に使う場合は adguard.nix を直接 import してください
 { lib, config, ... }:
 
 {
   imports = [
-    ./warp.nix
     ./adguard.nix
   ];
 
   options.sashix.networkProtection = {
-    enable = lib.mkEnableOption "network protection (WARP + AdGuard)";
+    enable = lib.mkEnableOption "network protection (AdGuard)";
   };
 
   config = lib.mkIf config.sashix.networkProtection.enable {
-    sashix.warp.enable   = lib.mkDefault true;
     sashix.adguard.enable = lib.mkDefault true;
   };
 }


### PR DESCRIPTION
- imports から ./warp.nix を削除
- config から sashix.warp.enable の自動有効化を削除
- モジュール説明を「WARP + AdGuard」から「AdGuard のみ」に更新
- warp.nix を使う場合は直接 import するよう案内コメントを追加

https://claude.ai/code/session_01XRJXHxLK84oYphdDpgpg9d