### PR TITLE
change default browser to brave in desktop.nix 

### DIFF
--- a/modules/desktop.nix
+++ b/modules/desktop.nix
@@ -25,7 +25,7 @@ in
 
     browserPackage = lib.mkOption {
       type        = lib.types.package;
-      default     = pkgs.floorp-bin;
+      default     = pkgs.brave;
       description = "Default browser package";
     };
 


### PR DESCRIPTION
floorp(Firefoxベース)の同梱を廃止し、以下の理由でFOSSであるBrave(Chromiumベース)へ変更
・Gnome-keyringとの連携およびこれに基づく認証情報データベースの暗号化
・拡張機能による広告ブロックとくらべ、Braveはネットワークスタックレベルの広告ブロックで最大限のリソース効率を維持している
・さらに広告ブロックにおいてAdGuardDNSと補完関係にある

fix #7 