### PR TITLE
Fix Cloudflare WARP and Tailscale integration issues

### DIFF
--- a/modules/adguard.nix
+++ b/modules/adguard.nix
@@ -93,19 +93,14 @@ in
       };
     };
 
-    # systemd-resolved: スタブリゾルバ (127.0.0.53)
-    # グローバル DNS: AdGuard Home のみ (Tailscale MagicDNS は tailscaled が per-link で自動設定)
-    #   100.100.100.100 をグローバルに入れると tailnet 外クエリが全て SERVFAIL になりノイズが増大
+    # systemd-resolved: AdGuard が有効な場合のみ DNS を 127.0.0.1 へ向ける
+    # enable/DNSStubListener は networking.nix で常時設定済み
     # FallbackDNS: AdGuard が応答不能の場合の最終手段
     #   LAN DNS (DHCP提供) は公衆無線でのポイズニングリスクがあるため使用しない
-    services.resolved = {
-      enable = true;
-      settings.Resolve = {
-        DNS            = "127.0.0.1";
-        FallbackDNS    = "9.9.9.9 149.112.112.112";
-        DNSSEC         = "allow-downgrade";
-        DNSStubListener = "yes";
-      };
+    services.resolved.settings.Resolve = {
+      DNS         = "127.0.0.1";
+      FallbackDNS = "9.9.9.9 149.112.112.112";
+      DNSSEC      = "allow-downgrade";
     };
   };
 }

--- a/modules/all.nix
+++ b/modules/all.nix
@@ -42,7 +42,10 @@
       yubikey.enable           = lib.mkDefault true;
       firewall.enable          = lib.mkDefault true;
       # warp と adguard は networkProtection に内包されるため個別設定不要
-      networkProtection.enable = lib.mkDefault true;
+      # WARP は Tailscale exit-node と競合するため、明示的にオプトインする設計にする
+      # (WARP が Connected 状態だと Tailscale の routing を上書きし、
+      #  100.64.0.0/10 を含む Tailscale 通信が WARP トンネルに吸われる)
+      networkProtection.enable = lib.mkDefault false;
       desktop.enable           = lib.mkDefault true;
       # nvidia はハードウェア依存のため false がデフォルト
       # NVIDIA GPU を搭載したマシンは configuration.nix で明示的に有効化する

--- a/modules/networking.nix
+++ b/modules/networking.nix
@@ -1,7 +1,8 @@
 # Network configuration
 # - NetworkManager for connection management
 # - MAC address randomization (privacy)
-# - systemd-resolved DNS forwarding
+# - systemd-resolved: スタブリゾルバ (127.0.0.53) を常時有効化
+#   DNS サーバの指定は各モジュールが上書き (AdGuard: 127.0.0.1 / デフォルト: NM が DHCP 提供)
 #
 # Tailscale VPN: see tailscale.nix
 # Firewall: see firewall.nix
@@ -26,7 +27,7 @@ in
     networking.hostName = cfg.hostName;
     networking.networkmanager.enable = true;
 
-    # Forward NetworkManager DNS config to systemd-resolved
+    # NetworkManager の DNS クエリを systemd-resolved 経由に転送
     networking.networkmanager.dns = "systemd-resolved";
 
     # MAC address randomization (プライバシー保護): 接続のたびに新しいランダムMACを使用
@@ -34,5 +35,13 @@ in
     #   nmcli connection modify "<SSID>" wifi.cloned-mac-address stable
     networking.networkmanager.wifi.macAddress     = "random";
     networking.networkmanager.ethernet.macAddress = "random";
+
+    # systemd-resolved: スタブリゾルバを常時有効化
+    # 127.0.0.53 をローカル DNS スタブとして提供し、NM 経由の全クエリを受け付ける
+    # DNS サーバ自体は adguard.nix (127.0.0.1) またはデフォルト (NM が DHCP で提供) が担当
+    services.resolved = {
+      enable = true;
+      settings.Resolve.DNSStubListener = "yes";
+    };
   };
 }

--- a/modules/tailscale.nix
+++ b/modules/tailscale.nix
@@ -12,5 +12,10 @@
 
   config = lib.mkIf config.sashix.tailscale.enable {
     services.tailscale.enable = true;
+
+    # exit-node クライアントとして使用するための設定
+    # checkReversePath = "loose" を有効にし、exit-node 経由の折り返しパケットを受け入れる
+    # "server" または "both" に上書きすれば exit-node のアドバタイズも可能
+    services.tailscale.useRoutingFeatures = lib.mkDefault "client";
   };
 }

--- a/modules/warp.nix
+++ b/modules/warp.nix
@@ -2,10 +2,10 @@
 #
 # --- tunnel_only モード (デフォルト) ---
 #   TCP/UDP 全通信を暗号化トンネル経由にする。DNS 制御は行わない。
-#   Split-tunnel exclusions (デフォルトで既に含まれている):
+#   Split-tunnel exclusions (cloudflare-warp-configure.service で明示設定):
 #     Tailnet:  100.64.0.0/10 (MagicDNS 100.100.100.100 を含む)
 #               fc00::/7     (fd7a:115c:a1e0::/48 を含む)
-#     LAN:      10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
+#     LAN:      10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 (WARP デフォルト)
 #
 # --- proxy モード ---
 #   全通信をトンネリングせず、ローカル SOCKS5/HTTPS プロキシを提供する。
@@ -65,6 +65,12 @@ in
         ''
         else ''
           ${pkgs.cloudflare-warp}/bin/warp-cli --accept-tos mode tunnel_only || true
+        '' + ''
+          # Tailscale 帯域を WARP トンネルから除外 (split-tunnel)
+          # これを設定しないと WARP が 100.64.0.0/10 を含む Tailscale 通信を
+          # WARP トンネルに吸い込み、exit-node / MagicDNS (100.100.100.100) が壊れる
+          ${pkgs.cloudflare-warp}/bin/warp-cli --accept-tos tunnel exclude add 100.64.0.0/10 || true
+          ${pkgs.cloudflare-warp}/bin/warp-cli --accept-tos tunnel exclude add fc00::/7      || true
         '';
     };
   };

--- a/modules/warp.nix
+++ b/modules/warp.nix
@@ -42,6 +42,11 @@ in
   config = lib.mkIf cfg.enable {
     services.cloudflare-warp.enable = true;
 
+    # WARP トンネルインターフェースをファイアウォールで信頼する
+    # tunnel_only モードでは CloudflareWARP インターフェース経由でトラフィックが流れるため、
+    # trustedInterfaces に追加しないとパケットが INPUT ルールでドロップされる
+    networking.firewall.trustedInterfaces = [ "CloudflareWARP" ];
+
     # モードを設定するサービス
     # WARP 未登録の場合はスキップ (登録後に restart して適用)
     systemd.services.cloudflare-warp-configure = {


### PR DESCRIPTION
## Summary
This PR fixes conflicts between Cloudflare WARP and Tailscale by properly configuring split-tunnel exclusions and adjusting default settings to prevent WARP from intercepting Tailscale traffic.

## Key Changes

- **WARP Split-Tunnel Configuration**: Added explicit split-tunnel exclusions for Tailscale address ranges (100.64.0.0/10 and fc00::/7) to prevent WARP from tunneling Tailscale traffic, which would break exit-node and MagicDNS functionality

- **Firewall Trust Configuration**: Added CloudflareWARP interface to trusted firewall interfaces to prevent packets from being dropped by INPUT rules in tunnel_only mode

- **Default Settings**: Changed `networkProtection.enable` default from `true` to `false` to require explicit opt-in, preventing automatic WARP activation that could conflict with Tailscale exit-node routing

- **Tailscale Routing Features**: Added explicit configuration for Tailscale routing features with `useRoutingFeatures = "client"` to support exit-node clients while allowing override to "server" or "both" for exit-node advertisement

- **Documentation**: Updated comments to clarify the relationship between WARP and Tailscale, explaining why split-tunnel exclusions are necessary and how the configuration prevents traffic interception

## Implementation Details

The core issue addressed is that WARP's tunnel_only mode was capturing Tailscale traffic (including the 100.64.0.0/10 range used for MagicDNS at 100.100.100.100), breaking Tailscale functionality. The fix uses WARP's split-tunnel feature to explicitly exclude these ranges, combined with firewall and default setting adjustments to ensure proper coexistence of both services.

https://claude.ai/code/session_01Ng9qnxxtbF4f9nTW1rADB4